### PR TITLE
refactor, support python3

### DIFF
--- a/auth.py
+++ b/auth.py
@@ -19,6 +19,8 @@ import os
 import sys
 import subprocess
 # workaround for ubuntu 12.04 / older python-six version
+from pip._vendor.distlib.compat import raw_input
+
 try:
     from six.moves import urllib
 except ImportError:
@@ -37,8 +39,9 @@ from oauth2client.client import AccessTokenRefreshError
 
 
 class Auth(object):
-    clientid = "843805314553.apps.googleusercontent.com"
-    clientsecret = 'MzTBsY4xlrD_lxkmwFbBrvBv'
+    # Use google/cloud-print-connector own clientid/clientsecret
+    clientid = "539833558011-35iq8btpgas80nrs3o7mv99hm95d4dv6.apps.googleusercontent.com"
+    clientsecret = 'V9BfPOvdiYuw12hDx5Y5nR0a'
     config = '/etc/cloudprint.conf'
     normal_permissions = 'https://www.googleapis.com/auth/cloudprint'
     http_thread = None
@@ -89,9 +92,9 @@ class Auth(object):
 
     @staticmethod
     def SetupHttpReturnServer():
-        import BaseHTTPServer
+        import http.server as BaseHTTPServer
         import random
-        import SocketServer
+        import socketserver as SocketServer
         from threading import Thread
         handler = BaseHTTPServer.BaseHTTPRequestHandler
 
@@ -153,11 +156,11 @@ class Auth(object):
             message += "( for the " + userid + " account ), "
             message += "then provide the code displayed : \n\n"
             message += auth_uri + "\n"
-            print message
+            print(message)
             Utils.openBrowserWithUrl(auth_uri)
             if url is not None:
                 from select import select
-                print 'Code from Google: '
+                print('Code from Google: ')
                 while (Auth.code is None):
                     result, _, _ = select([sys.stdin], [], [], 0.5)
                     if result and Auth.code is None:
@@ -174,7 +177,7 @@ class Auth(object):
             except Exception as e:
                 message = "\nThe code does not seem to be valid ( "
                 message += str(e) + " ), please try again.\n"
-                print message
+                print(message)
 
     @staticmethod
     def AddAccountStep1(userid, permissions=None, redirect_uri=None):

--- a/backend.py
+++ b/backend.py
@@ -76,22 +76,22 @@ if __name__ == '__main__':  # pragma: no cover
     printer_manager = PrinterManager(requestors)
 
     if len(sys.argv) == 1:
-        print 'network ' + Utils.PROTOCOL_NAME + ' "Unknown" "Google Cloud Print"'
+        print('network ' + Utils.PROTOCOL_NAME + ' "Unknown" "Google Cloud Print"')
 
         printers = printer_manager.getPrinters()
         if printers is not None:
             try:
                 for printer in printers:
-                    print printer.getCUPSBackendDescription()
+                    print(printer.getCUPSBackendDescription())
             except Exception as error:
                 sys.stderr.write("ERROR: " + error)
                 logging.error(error)
                 sys.exit(1)
         sys.exit(0)
 
-    filedata = ""
-    for line in sys.stdin:
-        filedata += line
+    filedata = sys.stdin.buffer.read()
+    # for line in sys.stdin:
+    #     filedata += line
 
     uri = os.getenv('DEVICE_URI')
     cupsprintername = os.getenv('PRINTER')

--- a/ccputils.py
+++ b/ccputils.py
@@ -105,8 +105,8 @@ class Utils(object):
         """
         p = subprocess.Popen(["file", '-'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         output = p.communicate(filedata)[0]
-        logging.debug("File output was: " + output)
-        return "PDF document" in output
+        logging.debug("File output was: " + str(output))
+        return "PDF document" in str(output)
 
     @staticmethod
     def is_exe(fpath):
@@ -168,7 +168,7 @@ class Utils(object):
     @staticmethod
     def ShowVersion(CCPVersion):
         if len(sys.argv) == 2 and sys.argv[1] == 'version':
-            print "CUPS Cloud Print Version " + CCPVersion
+            print("CUPS Cloud Print Version " + CCPVersion)
             sys.exit(0)
         return False
 
@@ -186,7 +186,7 @@ class Utils(object):
             s = f.read()
             return s
         except IOError as e:
-            print 'ERROR: Error opening %s\n%s', pathname, e
+            print('ERROR: Error opening %s\n%s', pathname, e)
             return None
 
     @staticmethod
@@ -215,7 +215,7 @@ class Utils(object):
         """Convert a file to a base64 encoded file.
 
         Args:
-          pathname: data to base64 encode
+          data: data to base64 encode
           jobtype: job type being encoded - pdf, jpg etc
         Returns:
           string, base64 encoded string.
@@ -227,7 +227,7 @@ class Utils(object):
         if jobtype in Utils._MIMETYPES_JOBTYPES:
             mimetype = Utils._MIMETYPES_JOBTYPES[jobtype]
         header = 'data:%s;base64,' % mimetype
-        return header + base64.b64encode(data)
+        return header + str(base64.b64encode(data), 'UTF-8')
 
     @staticmethod
     def GetLanguage(locale, cupshelper=None):
@@ -291,7 +291,7 @@ class Utils(object):
 
         if not OUT:
             logging.error("Cannot write temp file: %s", tempFile)
-            print "ERROR: Cannot write " + tempFile
+            print("ERROR: Cannot write " + tempFile)
             sys.exit(1)
 
         for line in stdin:

--- a/cupshelper.py
+++ b/cupshelper.py
@@ -18,7 +18,6 @@ from ccputils import Utils
 
 import cups
 
-
 class CUPSHelper(object):
     def __init__(self, connection=None):
         if connection is None:
@@ -52,7 +51,7 @@ class CUPSHelper(object):
 
     def getPrinters(self):
         printers = self._connection.getPrinters()
-        return dict((name, printer) for (name, printer) in printers.iteritems()
+        return dict((name, printer) for (name, printer) in printers.items()
                     if printer['device-uri'].startswith(Utils.PROTOCOL))
 
     def deletePrinter(self, uri):
@@ -92,8 +91,8 @@ class CUPSHelper(object):
             error = e
 
         if error is not None:
-            print 'Error adding: %s' % name
-            print error
+            print('Error adding: %s' % name)
+            print(error)
             return False
 
         return True

--- a/deleteaccount.py
+++ b/deleteaccount.py
@@ -23,6 +23,7 @@ exit $?
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from pip._vendor.distlib.compat import raw_input
 
 if __name__ == '__main__':  # pragma: no cover
     import sys
@@ -46,22 +47,22 @@ if __name__ == '__main__':  # pragma: no cover
     while True:
         result, storage = Auth.SetupAuth(False)
         if not result:
-            print "No accounts are currently setup"
+            print("No accounts are currently setup")
             break
         else:
             requestors = result
-            print "You currently have these accounts configured: "
+            print("You currently have these accounts configured: ")
             i = 0
             accounts = []
             for requestor in requestors:
                 i += 1
                 accounts.append(requestor.getAccount())
-                print str(i) + ") " + requestor.getAccount()
-            print "0) Exit"
+                print(str(i) + ") " + requestor.getAccount())
+            print("0) Exit")
             answer = raw_input("Which account to delete (1-" + str(i) + ") ? ")
             if (answer.isdigit() and int(answer) <= i and int(answer) >= 1):
                 if (Auth.DeleteAccount(accounts[int(answer) - 1]) is None):
-                    print accounts[int(answer) - 1] + " deleted."
+                    print(accounts[int(answer) - 1] + " deleted.")
                     deleteprintersanswer = raw_input(
                         "Also delete associated printers? ")
                     if deleteprintersanswer.lower().startswith("y"):
@@ -69,24 +70,24 @@ if __name__ == '__main__':  # pragma: no cover
                         printers = \
                             printer_manager.getCUPSPrintersForAccount(accounts[int(answer) - 1])
                         if len(printers) == 0:
-                            print "No printers to delete"
+                            print("No printers to delete")
                         else:
                             for cupsPrinter in printers:
-                                print "Deleting " + cupsPrinter['printer-info']
+                                print("Deleting " + cupsPrinter['printer-info'])
                                 deleteReturnValue = cupsHelper.deletePrinter(
                                     cupsPrinter['printer-info'])
                                 if deleteReturnValue is not None:
                                     errormessage = "Error deleting printer: "
                                     errormessage += str(deleteReturnValue)
-                                    print errormessage
+                                    print(errormessage)
                     else:
-                        print "Not deleting associated printers"
+                        print("Not deleting associated printers")
                 else:
                     errormessage = "Error deleting stored "
                     errormessage += "credentials, perhaps "
                     errormessage += Auth.config + " is not writable?"
-                    print errormessage
+                    print(errormessage)
             elif (answer == "0"):
                 break
             else:
-                print "Invalid response, use '0' to exit"
+                print("Invalid response, use '0' to exit")

--- a/dynamicppd.py
+++ b/dynamicppd.py
@@ -37,7 +37,7 @@ def doList(sys, printer_manager):
         sys.stderr.write("ERROR: No Printers Found\n")
         sys.exit(1)
     for printer in printers:
-        print printer.getCUPSDriverDescription()
+        print(printer.getCUPSDriverDescription())
     sys.exit(0)
 
 
@@ -61,7 +61,7 @@ def doCat():
         sys.stderr.write("ERROR: PPD %s not found\n" % sys.argv[2])
         sys.exit(1)
 
-    print printer.generatePPD()
+    print(printer.generatePPD())
 
     sys.exit(0)
 

--- a/listcloudprinters.py
+++ b/listcloudprinters.py
@@ -40,8 +40,8 @@ if __name__ == '__main__':  # pragma: no cover
     printer_manager = PrinterManager(requestors)
     printers = printer_manager.getPrinters()
     if printers is None:
-        print "No Printers Found"
+        print("No Printers Found")
         sys.exit(1)
 
     for printer in printers:
-        print printer.getListDescription()
+        print(printer.getListDescription())

--- a/oauth2client/tools.py
+++ b/oauth2client/tools.py
@@ -29,6 +29,7 @@ import socket
 import sys
 import webbrowser
 
+from pip._vendor.distlib.compat import raw_input
 from six.moves import BaseHTTPServer
 from six.moves import urllib
 

--- a/pre-commit.py
+++ b/pre-commit.py
@@ -57,8 +57,8 @@ if __name__ == '__main__':  # pragma: no cover
                 stdout=subprocess.PIPE)
             pep8output = p2.communicate()[0].strip()
             if p2.returncode != 0:
-                print alteredfile, "failed pep8 check:"
-                print pep8output
+                print(alteredfile, "failed pep8 check:")
+                print(pep8output)
             testfile = open(alteredfile, "r")
             fileNeedsUpdating = False
             for line in testfile:

--- a/printermanager.py
+++ b/printermanager.py
@@ -13,7 +13,8 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import email.generator
+import binascii
+import os
 import re
 from auth import Auth
 from urllib.parse import urlparse,unquote
@@ -23,7 +24,7 @@ from ccputils import Utils
 
 
 class PrinterManager(object):
-    BOUNDARY = email.generator._make_boundary()
+    BOUNDARY = binascii.hexlify(os.urandom(16)).decode('ascii')
     CRLF = '\r\n'
     requestors = None
     cachedPrinterDetails = {}

--- a/printermanager.py
+++ b/printermanager.py
@@ -13,30 +13,27 @@
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import urllib
-import mimetools
+import email.generator
 import re
 from auth import Auth
-from urlparse import urlparse
+from urllib.parse import urlparse,unquote
 from printer import Printer
 from cupshelper import CUPSHelper
 from ccputils import Utils
 
 
 class PrinterManager(object):
-    BOUNDARY = mimetools.choose_boundary()
+    BOUNDARY = email.generator._make_boundary()
     CRLF = '\r\n'
     requestors = None
     cachedPrinterDetails = {}
-    reservedCapabilityWords = set((
-        'Duplex', 'Resolution', 'Attribute', 'Choice', 'ColorDevice', 'ColorModel', 'ColorProfile',
-        'Copyright', 'CustomMedia', 'Cutter', 'Darkness', 'DriverType', 'FileName', 'Filter',
-        'Filter', 'Finishing', 'Font', 'Group', 'HWMargins', 'InputSlot', 'Installable',
-        'LocAttribute', 'ManualCopies', 'Manufacturer', 'MaxSize', 'MediaSize', 'MediaType',
-        'MinSize', 'ModelName', 'ModelNumber', 'Option', 'PCFileName', 'SimpleColorProfile',
-        'Throughput', 'UIConstraints', 'VariablePaperSize', 'Version', 'Color', 'Background',
-        'Stamp', 'DestinationColorProfile'
-    ))
+    reservedCapabilityWords = {'Duplex', 'Resolution', 'Attribute', 'Choice', 'ColorDevice', 'ColorModel',
+                               'ColorProfile', 'Copyright', 'CustomMedia', 'Cutter', 'Darkness', 'DriverType',
+                               'FileName', 'Filter', 'Filter', 'Finishing', 'Font', 'Group', 'HWMargins', 'InputSlot',
+                               'Installable', 'LocAttribute', 'ManualCopies', 'Manufacturer', 'MaxSize', 'MediaSize',
+                               'MediaType', 'MinSize', 'ModelName', 'ModelNumber', 'Option', 'PCFileName',
+                               'SimpleColorProfile', 'Throughput', 'UIConstraints', 'VariablePaperSize', 'Version',
+                               'Color', 'Background', 'Stamp', 'DestinationColorProfile'}
     URIFormatLatest = 9999
     URIFormat20140308 = 3
     URIFormat20140307 = 2
@@ -120,7 +117,10 @@ class PrinterManager(object):
         Returns:
           string: CUPS-friendly name for the printer
         """
-        return re.sub('[^a-zA-Z0-9\-_]', '', name.encode('ascii', 'replace').replace(' ', '_'))
+        name = name if isinstance(name, str) else str(name)
+        name = str(name.encode('ascii', 'replace'), 'UTF-8').replace(' ', '_')
+
+        return re.sub('[^a-zA-Z0-9\-_]', '', name)
 
     def addPrinter(self, printername, printer, location=None, ppd=None):
         """Adds a printer to CUPS
@@ -155,17 +155,17 @@ class PrinterManager(object):
             result = False
             errorMessage = error
         if result:
-            print "Added " + printername
+            print("Added " + printername)
             return True
         else:
-            print "Error adding: " + printername, errorMessage
+            print("Error adding: " + printername, errorMessage)
             return False
 
     @staticmethod
     def _getAccountNameAndPrinterIdFromURI(uri):
         splituri = uri.rsplit('/', 2)
-        accountName = urllib.unquote(splituri[1])
-        printerId = urllib.unquote(splituri[2])
+        accountName = unquote(splituri[1])
+        printerId = unquote(splituri[2])
         return accountName, printerId
 
     def parseLegacyURI(self, uristring, requestors):
@@ -189,24 +189,24 @@ class PrinterManager(object):
         if uri.scheme == Utils.OLD_PROTOCOL_NAME:
             if len(pathparts) == 2:
                 formatId = PrinterManager.URIFormat20140307
-                printerId = urllib.unquote(pathparts[1])
-                accountName = urllib.unquote(pathparts[0])
-                printerName = urllib.unquote(uri.netloc)
+                printerId = unquote(pathparts[1])
+                accountName = unquote(pathparts[0])
+                printerName = unquote(uri.netloc)
             else:
-                if urllib.unquote(uri.netloc) not in Auth.GetAccountNames(requestors):
+                if unquote(uri.netloc) not in Auth.GetAccountNames(requestors):
                     formatId = PrinterManager.URIFormat20140210
-                    printerName = urllib.unquote(uri.netloc)
-                    accountName = urllib.unquote(pathparts[0])
+                    printerName = unquote(uri.netloc)
+                    accountName = unquote(pathparts[0])
                 else:
                     formatId = PrinterManager.URIFormat20140308
-                    printerId = urllib.unquote(pathparts[0])
+                    printerId = unquote(pathparts[0])
                     printerName = None
-                    accountName = urllib.unquote(uri.netloc)
+                    accountName = unquote(uri.netloc)
         elif uri.scheme == Utils.PROTOCOL_NAME:
             formatId = PrinterManager.URIFormatLatest
-            printerId = urllib.unquote(pathparts[0])
+            printerId = unquote(pathparts[0])
             printerName = None
-            accountName = urllib.unquote(uri.netloc)
+            accountName = unquote(uri.netloc)
 
         return accountName, printerName, printerId, formatId
 
@@ -236,7 +236,7 @@ class PrinterManager(object):
           requestor: Single requestor object for the account
         """
         # find requestor based on account
-        requestor = self.findRequestorForAccount(urllib.unquote(account))
+        requestor = self.findRequestorForAccount(unquote(account))
         if requestor is None:
             return None, None
 

--- a/reportissues.py
+++ b/reportissues.py
@@ -47,15 +47,15 @@ if __name__ == '__main__':  # pragma: no cover
     printer_manager = PrinterManager(requestors)
     printers = printer_manager.getPrinters()
     if printers is None:
-        print "ERROR: No Printers Found"
+        print("ERROR: No Printers Found")
         sys.exit(1)
 
     for printer in printers:
-        print printer.getCUPSDriverDescription()
-        print ""
-        print printer.getFields()
-        print printer['capabilities']
-        print "\n"
+        print(printer.getCUPSDriverDescription())
+        print("")
+        print(printer.getFields())
+        print(printer['capabilities'])
+        print("\n")
         ppdname = printer.getPPDName()
         p1 = subprocess.Popen(
             (os.path.join(libpath, 'dynamicppd.py'), 'cat', ppdname.lstrip('-')),
@@ -64,9 +64,9 @@ if __name__ == '__main__':  # pragma: no cover
         p = subprocess.Popen(['cupstestppd', '-'], stdout=subprocess.PIPE, stdin=subprocess.PIPE)
         testdata = p.communicate(ppddata)[0]
         result = p.returncode
-        print "Result of cupstestppd was " + str(result)
-        print "".join(testdata)
+        print("Result of cupstestppd was " + str(result))
+        print("".join(testdata))
         if result != 0:
-            print "cupstestppd errored: "
-            print ppddata
-            print "\n"
+            print("cupstestppd errored: ")
+            print(ppddata)
+            print("\n")

--- a/setupcloudprint.py
+++ b/setupcloudprint.py
@@ -23,6 +23,7 @@ exit $?
 #
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+from pip._vendor.msgpack.fallback import xrange
 
 
 def printPrinters(printers):
@@ -44,7 +45,7 @@ def printPrinters(printers):
     window_size = Utils.GetWindowSize()
     if window_size is None or window_size[0] > len(printer_names):
         for printer_name in printer_names:
-            print printer_name
+            print(printer_name)
     else:
         window_width = window_size[1]
         max_name_length = max((len(printer_name) for printer_name in printer_names))
@@ -56,7 +57,7 @@ def printPrinters(printers):
             row_printers = []
             for printer_name in printer_names[row_i::row_quantity]:
                 row_printers.append(printer_name.ljust(max_name_length))
-            print ' '.join(row_printers)
+            print(' '.join(row_printers))
     return len(printers)
 
 if __name__ == '__main__':  # pragma: no cover
@@ -112,22 +113,22 @@ if __name__ == '__main__':  # pragma: no cover
             data = json.loads(content)
         except Exception:
             # remove old config file
-            print "Deleting old configuration file: " + Auth.config
+            print("Deleting old configuration file: " + Auth.config)
             os.remove(Auth.config)
 
     while True:
         requestors, storage = Auth.SetupAuth(interactive=False)
         if storage is not False:
-            print "You currently have these accounts configured: "
+            print("You currently have these accounts configured: ")
             for requestor in requestors:
-                print requestor.getAccount()
+                print(requestor.getAccount())
             add_account = len(requestors) == 0
         else:
             add_account = True
         if not add_account:
             if not options.interactive:
                 break
-            answer = raw_input("Add more accounts (Y/N)? ")
+            answer = input("Add more accounts (Y/N)? ")
             if answer.lower().startswith("y"):
                 add_account = True
             else:
@@ -142,22 +143,22 @@ if __name__ == '__main__':  # pragma: no cover
         printer_manager = PrinterManager(requestor)
         printers = printer_manager.getPrinters()
         if printers is None:
-            print "Sorry, no printers were found on your Google Cloud Print account."
+            print("Sorry, no printers were found on your Google Cloud Print account.")
             continue
 
         if options.add_all.lower() == "y":
             answer = "y"
         else:
-            answer = raw_input("Add all Google Cloud Print printers from %s to CUPS (Y/N)? " %
+            answer = input("Add all Google Cloud Print printers from %s to CUPS (Y/N)? " %
                                requestor.getAccount())
 
         if not answer.lower().startswith("y"):
             answer = 1
-            print "Not adding printers automatically"
+            print("Not adding printers automatically")
 
             while int(answer) != 0:
                 maxprinterid = printPrinters(printers)
-                answer = raw_input("Add printer (1-%d, 0 to cancel)? " % maxprinterid)
+                answer = input("Add printer (1-%d, 0 to cancel)? " % maxprinterid)
                 try:
                     answer = int(answer)
                 except ValueError:
@@ -165,19 +166,19 @@ if __name__ == '__main__':  # pragma: no cover
                 if answer == 0:
                     continue
                 if answer < 1 or answer > maxprinterid:
-                    print "\nPrinter %d not found\n" % answer
+                    print("\nPrinter %d not found\n" % answer)
                     continue
 
                 ccpprinter = printers[answer - 1]
-                print "Adding " + printers[answer - 1]['displayName']
+                print("Adding " + printers[answer - 1]['displayName'])
                 printername = options.prefix + \
-                    ccpprinter.getDisplayName().encode('ascii', 'replace')
+                    str(ccpprinter.getDisplayName().encode('ascii', 'replace'), 'UTF-8')
                 found = False
                 for cupsprinter in cupsprinters:
                     if cupsprinters[cupsprinter]['device-uri'] == ccpprinter.getURI():
                         found = True
                 if found:
-                    print "\nPrinter with %s already exists\n" % printername
+                    print("\nPrinter with %s already exists\n" % printername)
                 else:
                     printer_manager.addPrinter(printername, ccpprinter)
 
@@ -202,17 +203,17 @@ if __name__ == '__main__':  # pragma: no cover
                         printer_manager.sanitizePrinterName(printername):
                     foundbyname = True
             if foundbyname:
-                answer = raw_input('Printer %s already exists, supply another name (Y/N)? ' %
+                answer = input('Printer %s already exists, supply another name (Y/N)? ' %
                                    printer_manager.sanitizePrinterName(printername))
                 if answer.startswith("Y") or answer.startswith("y"):
-                    printername = raw_input("New printer name? ")
+                    printername = input("New printer name? ")
                 else:
-                    answer = raw_input("Overwrite %s with new printer (Y/N)? " %
+                    answer = input("Overwrite %s with new printer (Y/N)? " %
                                        printer_manager.sanitizePrinterName(printername))
                     if answer.lower().startswith("n"):
                         printername = ""
             elif foundbyname:
-                print "Not adding printer %s, as already exists" % printername
+                print("Not adding printer %s, as already exists" % printername)
                 printername = ""
 
             if printername != "":
@@ -221,9 +222,9 @@ if __name__ == '__main__':  # pragma: no cover
                 addedCount += 1
 
         if addedCount > 0:
-            print "Added %d new printers to CUPS" % addedCount
+            print("Added %d new printers to CUPS" % addedCount)
         else:
-            print "No new printers to add"
+            print("No new printers to add")
 
     printer_uris = []
     printer_manager = PrinterManager(requestors)
@@ -241,16 +242,16 @@ if __name__ == '__main__':  # pragma: no cover
             prunePrinters.append(cupsprinter)
 
     if len(prunePrinters) > 0:
-        print "Found %d printers which no longer exist on cloud print:" % len(prunePrinters)
+        print("Found %d printers which no longer exist on cloud print:" % len(prunePrinters))
         for printer in prunePrinters:
-            print printer
+            print(printer)
         if options.auto_clean.lower() == "y":
             answer = "y"
         else:
-            answer = raw_input("Remove (Y/N)? ")
+            answer = input("Remove (Y/N)? ")
         if answer.lower().startswith("y"):
             for printer in prunePrinters:
                 cupsHelper.deletePrinter(printer)
-                print "Deleted", printer
+                print("Deleted", printer)
         else:
-            print "Not removing old printers"
+            print("Not removing old printers")

--- a/setupcloudprintgui.py
+++ b/setupcloudprintgui.py
@@ -29,17 +29,17 @@ from ccputils import Utils
 from cupshelper import CUPSHelper
 from printermanager import PrinterManager
 
-import Tkinter
-import tkMessageBox
+import tkinter
+import tkinter.ttk
+import tkinter.messagebox as tkMessageBox
 import time
-import ttk
-import urllib
+import urllib.parse
 import webbrowser
 
 
-class PrinterNameLocationDialog(Tkinter.Toplevel):
+class PrinterNameLocationDialog(tkinter.Toplevel):
     def __init__(self, master, uri, name, location, callback):
-        Tkinter.Toplevel.__init__(self, master)
+        tkinter.Toplevel.__init__(self, master)
         self.master = master
         self.uri = uri
         self.callback = callback
@@ -47,18 +47,18 @@ class PrinterNameLocationDialog(Tkinter.Toplevel):
         self.transient(master)  # don't create an icon in the system tray, etc
         self.title('printer name, location')
 
-        ttk.Label(self, text='printer name:').grid(column=0, row=0, sticky='w')
-        ttk.Label(self, text='location:').grid(column=0, row=1, sticky='w')
-        self.name = ttk.Entry(self)
+        tkinter.Label(self, text='printer name:').grid(column=0, row=0, sticky='w')
+        tkinter.Label(self, text='location:').grid(column=0, row=1, sticky='w')
+        self.name = tkinter.Entry(self)
         self.name.insert(0, name)
         self.name.grid(column=1, row=0)
-        self.location = ttk.Entry(self)
+        self.location = tkinter.Entry(self)
         self.location.insert(0, location)
         self.location.grid(column=1, row=1)
 
-        box = ttk.Frame(self)
-        ttk.Button(box, text='OK', command=self.ok, default='active').pack(side='left')
-        ttk.Button(box, text='Cancel', command=self.cancel).pack(side='left')
+        box = tkinter.Frame(self)
+        tkinter.Button(box, text='OK', command=self.ok, default='active').pack(side='left')
+        tkinter.Button(box, text='Cancel', command=self.cancel).pack(side='left')
         box.grid(column=0, row=2, columnspan=2)
 
         self.name.focus()
@@ -82,15 +82,15 @@ class PrinterNameLocationDialog(Tkinter.Toplevel):
         self.destroy()
 
 
-class PrintersTab(ttk.Frame):
+class PrintersTab(tkinter.Frame):
     def __init__(self, master, window, **kw):
-        ttk.Frame.__init__(self, master, **kw)
+        tkinter.Frame.__init__(self, master, **kw)
         self.window = window
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
 
-        self.tree = ttk.Treeview(self,
+        self.tree = tkinter.ttk.Treeview(self,
                                  columns=('name', 'location'),
                                  displaycolumns=('name', 'location'),
                                  height=20,
@@ -104,10 +104,10 @@ class PrintersTab(ttk.Frame):
 
         self.tree.grid(column=0, row=0, sticky='nwes', pady=(6, 6))
 
-        box = ttk.Frame(self)
-        ttk.Button(box, text='rename', command=self._invokeRenameDialog, default='active').pack(
+        box = tkinter.Frame(self)
+        tkinter.Button(box, text='rename', command=self._invokeRenameDialog, default='active').pack(
             side='left')
-        ttk.Button(box, text='remove', command=self._remove).pack(side='left')
+        tkinter.Button(box, text='remove', command=self._remove).pack(side='left')
         box.grid(column=0, row=1)
 
     def _initPrinters(self):
@@ -154,18 +154,18 @@ class AddPrinterDialogPrinter(object):
             return -1
         if self.display_name.lower() > other.display_name.lower():
             return 1
-        return cmp(self.location.lower(), other.location.lower())
+        return (lambda a, b: (a > b) - (a < b))(self.location.lower(), other.location.lower())
 
 
-class AddPrinterTab(ttk.Frame):
+class AddPrinterTab(tkinter.Frame):
     def __init__(self, master, window, **kw):
-        ttk.Frame.__init__(self, master, **kw)
+        tkinter.Frame.__init__(self, master, **kw)
         self.window = window
 
         self.columnconfigure(1, weight=1)
         self.rowconfigure(1, weight=1)
 
-        self.tree = ttk.Treeview(self,
+        self.tree = tkinter.ttk.Treeview(self,
                                  columns=('name', 'location'),
                                  displaycolumns=('name', 'location'),
                                  height=20,
@@ -179,14 +179,14 @@ class AddPrinterTab(ttk.Frame):
 
         self.tree.grid(column=0, row=1, columnspan=2, sticky='nwes', pady=(6, 6))
 
-        search_label = ttk.Label(self, text='search: ')
+        search_label = tkinter.Label(self, text='search: ')
         search_label.grid(column=0, row=0, sticky='w')
 
-        self.search = ttk.Entry(self, exportselection=False, validate='key',
+        self.search = tkinter.Entry(self, exportselection=False, validate='key',
                                 validatecommand=(self.register(self._filterPrinters), '%P'))
         self.search.grid(column=1, row=0, sticky='we')
 
-        self.add_button = ttk.Button(self, text='add this printer', command=self._invokeAddDialog)
+        self.add_button = tkinter.Button(self, text='add this printer', command=self._invokeAddDialog)
         self.add_button.grid(column=1, row=2, sticky='e')
 
         self.search.bind('<Control-BackSpace>', self._clearQuery)
@@ -256,24 +256,24 @@ class AddPrinterTab(ttk.Frame):
         self.search.focus()
 
 
-class NewAccountDialogStep1(Tkinter.Toplevel):
+class NewAccountDialogStep1(tkinter.Toplevel):
     def __init__(self, master, callback):
-        Tkinter.Toplevel.__init__(self, master)
+        tkinter.Toplevel.__init__(self, master)
         self.master = master
         self.callback = callback
 
         self.transient(master)  # don't create an icon in the system tray, etc
         self.title('new account, step 1')
 
-        box = ttk.Frame(self)
-        ttk.Label(box, text='account name (eg something@gmail.com): ').pack(side='left')
-        self.account_name = ttk.Entry(box)
+        box = tkinter.Frame(self)
+        tkinter.Label(box, text='account name (eg something@gmail.com): ').pack(side='left')
+        self.account_name = tkinter.Entry(box)
         self.account_name.pack(side='left')
         box.grid(column=0, row=0)
 
-        box2 = ttk.Frame(self)
-        ttk.Button(box2, text='OK', command=self.ok).pack(side='left')
-        ttk.Button(box2, text='Cancel', command=self.cancel).pack(side='left')
+        box2 = tkinter.Frame(self)
+        tkinter.Button(box2, text='OK', command=self.ok).pack(side='left')
+        tkinter.Button(box2, text='Cancel', command=self.cancel).pack(side='left')
         box2.grid(column=0, row=1)
 
         self.account_name.focus()
@@ -297,9 +297,9 @@ class NewAccountDialogStep1(Tkinter.Toplevel):
         self.destroy()
 
 
-class NewAccountDialogStep2(Tkinter.Toplevel):
+class NewAccountDialogStep2(tkinter.Toplevel):
     def __init__(self, master, account_name, flow, auth_uri, callback):
-        Tkinter.Toplevel.__init__(self, master)
+        tkinter.Toplevel.__init__(self, master)
         self.master = master
         self.account_name = account_name
         self.flow = flow
@@ -310,29 +310,29 @@ class NewAccountDialogStep2(Tkinter.Toplevel):
         self.title('new account, step 2')
 
         message = 'Visit this URL to grant printer access to CUPS Cloud Print'
-        ttk.Label(self, text=message).grid(column=0, row=0)
-        uri_text = Tkinter.Text(self, width=100, height=3)
+        tkinter.Label(self, text=message).grid(column=0, row=0)
+        uri_text = tkinter.Text(self, width=100, height=3)
         uri_text.insert('insert', auth_uri)
         uri_text.tag_add('sel', '1.0', 'end')
         uri_text.grid(column=0, row=1)
         uri_text.focus()
 
-        box = ttk.Frame(self)
-        ttk.Button(box, text='copy URL to clipboard', command=self._copyToClipboard).pack(
+        box = tkinter.Frame(self)
+        tkinter.Button(box, text='copy URL to clipboard', command=self._copyToClipboard).pack(
             side='left')
-        ttk.Button(box, text='open URL in web browser', command=self._openUriInBrowser).pack(
+        tkinter.Button(box, text='open URL in web browser', command=self._openUriInBrowser).pack(
             side='left')
         box.grid(column=0, row=2)
 
         message2 = 'Google gives you a code, paste it here'
-        ttk.Label(self, text=message2).grid(column=0, row=3)
+        tkinter.Label(self, text=message2).grid(column=0, row=3)
 
-        self.code_entry = ttk.Entry(self, width=60)
+        self.code_entry = tkinter.Entry(self, width=60)
         self.code_entry.grid(column=0, row=4)
 
-        box2 = ttk.Frame(self)
-        ttk.Button(box2, text='OK', command=self.ok).pack(side='left')
-        ttk.Button(box2, text='Cancel', command=self.cancel).pack(side='left')
+        box2 = tkinter.Frame(self)
+        tkinter.Button(box2, text='OK', command=self.ok).pack(side='left')
+        tkinter.Button(box2, text='Cancel', command=self.cancel).pack(side='left')
         box2.grid(column=0, row=5)
 
         self.bind('<Return>', self.ok)
@@ -366,15 +366,15 @@ class NewAccountDialogStep2(Tkinter.Toplevel):
         self.destroy()
 
 
-class AccountsTab(ttk.Frame):
+class AccountsTab(tkinter.Frame):
     def __init__(self, master, window, **kw):
-        ttk.Frame.__init__(self, master, **kw)
+        tkinter.Frame.__init__(self, master, **kw)
         self.window = window
 
         self.columnconfigure(0, weight=1)
         self.rowconfigure(0, weight=1)
 
-        self.tree = ttk.Treeview(self,
+        self.tree = tkinter.ttk.Treeview(self,
                                  columns=('account',),
                                  displaycolumns=('account',),
                                  height=20,
@@ -386,10 +386,10 @@ class AccountsTab(ttk.Frame):
 
         self.tree.grid(column=0, row=0, sticky='nwes', pady=(6, 6))
 
-        box = ttk.Frame(self)
-        self.add_button = ttk.Button(box, text='add an account', command=self._showStep1)
+        box = tkinter.Frame(self)
+        self.add_button = tkinter.Button(box, text='add an account', command=self._showStep1)
         self.add_button.pack(side='left')
-        self.remove_button = ttk.Button(box, text='remove this account', command=self._remove)
+        self.remove_button = tkinter.Button(box, text='remove this account', command=self._remove)
         self.remove_button.pack(side='left')
         box.grid(column=0, row=1)
 
@@ -415,7 +415,7 @@ class AccountsTab(ttk.Frame):
             return
 
         # remove printers belonging to the deleted account
-        uri_prefix = Utils.PROTOCOL + urllib.quote(account_name.encode('ascii', 'replace')) + '/'
+        uri_prefix = Utils.PROTOCOL + urllib.parse.quote(account_name.encode('ascii', 'replace')) + '/'
         for cups_printer in self.window.getCUPSHelper().getPrinters().values():
             if cups_printer['device-uri'].startswith(uri_prefix):
                 self.window.getCUPSHelper().deletePrinter(cups_printer['device-uri'])
@@ -445,10 +445,10 @@ class Window(object):
         self.cups_helper = CUPSHelper()
         self.resetAccounts()
 
-        root = Tkinter.Tk()
+        root = tkinter.Tk()
         root.title('CUPS Cloud Print')
 
-        notebook = ttk.Notebook(root)
+        notebook = tkinter.ttk.Notebook(root)
         printers_tab = PrintersTab(notebook, self)
         self._add_printer_tab = AddPrinterTab(notebook, self)
         accounts_tab = AccountsTab(notebook, self)
@@ -497,7 +497,7 @@ class Window(object):
                     '%s %s' % (p.getDisplayName().lower(), p.getLocation().lower()),
                     p))
             td = time.time() - td
-            print 'get ccp printers took %.2f seconds' % td
+            print('get ccp printers took %.2f seconds' % td)
             self._ccp_printers = sorted(ccp_printers)
 
         return self._ccp_printers

--- a/testing/listdrivefiles.py
+++ b/testing/listdrivefiles.py
@@ -31,7 +31,7 @@ def getDriveFiles(requestors):
         responseobj = requestor.doRequest(
             'files', endpointurl="https://www.googleapis.com/drive/v2")
         if 'error' in responseobj:
-            print "Errored fetching files from drive"
+            print("Errored fetching files from drive")
         else:
             for item in responseobj['items']:
                 returnValue.append(item)
@@ -57,12 +57,12 @@ if __name__ == '__main__':  # pragma: no cover
                                     'https://www.googleapis.com/auth/drive.readonly'])
     files = getDriveFiles(requestors)
     if files is None:
-        print "No Files Found"
+        print("No Files Found")
         sys.exit(1)
 
     for drivefile in files:
         if len(sys.argv) == 2 and drivefile['title'] == sys.argv[1] + '.pdf':
-            print drivefile['fileSize']
+            print(drivefile['fileSize'])
             sys.exit(0)
         elif len(sys.argv) != 2:
-            print drivefile['title']
+            print(drivefile['title'])

--- a/upgrade.py
+++ b/upgrade.py
@@ -95,9 +95,9 @@ if __name__ == '__main__':  # pragma: no cover
         sys.exit(1)
 
     try:
-        print "Fetching list of available ppds..."
+        print("Fetching list of available ppds...")
         allppds = cupsHelper.getPPDs()
-        print "List retrieved successfully"
+        print("List retrieved successfully")
     except Exception as e:
         sys.stderr.write("Error connecting to CUPS: " + str(e) + "\n")
         sys.exit(1)
@@ -115,7 +115,7 @@ if __name__ == '__main__':  # pragma: no cover
                     updatingmessage = "Updating "
                     updatingmessage += cupsprinters[device]["printer-info"]
                     updatingmessage += " with new id uri format"
-                    print updatingmessage
+                    print(updatingmessage)
                     tempprinter = None
                     printerid, requestor = printer_manager.getPrinterIDByDetails(
                         account, printerid)
@@ -140,10 +140,10 @@ if __name__ == '__main__':  # pragma: no cover
                         errormessage += " not found, "
                         errormessage += "you should delete and "
                         errormessage += "re-add this printer"
-                        print errormessage
+                        print(errormessage)
                         continue
                 else:
-                    print "Updating " + cupsprinters[device]["printer-info"]
+                    print("Updating " + cupsprinters[device]["printer-info"])
 
                 ppdid = 'MFG:Google;DRV:GCP;CMD:POSTSCRIPT;DES:GoogleCloudPrint;MDL:' + \
                     cupsprinters[device]["device-uri"]
@@ -168,6 +168,6 @@ if __name__ == '__main__':  # pragma: no cover
                     errormessage = cupsprinters[device]["printer-info"]
                     errormessage += " not found, you should delete and"
                     errormessage += " re-add this printer"
-                    print errormessage
+                    print(errormessage)
         except Exception as e:
             sys.stderr.write("Error connecting to CUPS: " + str(e) + "\n")


### PR DESCRIPTION
- use clientid/clientsecret from github:google/cloud-print-connector repo

send PDF example

```bash
$ export DEVICE_URI=gcp://`username`%40`domain.tld`/`printer-id`
$ export PRINTER="`PrinterName`"
$ python3 /usr/local/share/cloudprint-cups/backend.py 1 "username" "example.pdf" 1 "" < ~/Downloads/example.pdf
```